### PR TITLE
Add edge thickness variable

### DIFF
--- a/src/optiland/optiland/optimization/variable/__init__.py
+++ b/src/optiland/optiland/optimization/variable/__init__.py
@@ -13,5 +13,6 @@ from .asphere_coeff import AsphereCoeffVariable
 from .polynomial_coeff import PolynomialCoeffVariable
 from .chebyshev_coeff import ChebyshevCoeffVariable
 from .zernike_coeff import ZernikeCoeffVariable
+from .edge_thickness import EdgeThicknessVariable
 from .variable import Variable
 from .variable_manager import VariableManager

--- a/src/optiland/optiland/optimization/variable/edge_thickness.py
+++ b/src/optiland/optiland/optimization/variable/edge_thickness.py
@@ -1,0 +1,51 @@
+"""Edge Thickness Variable Module
+
+This module defines the :class:`EdgeThicknessVariable` which represents
+thickness measured at a chosen radial distance from the optical axis. It
+allows constraining the edge thickness between two surfaces during
+optimization.
+"""
+
+import optiland.backend as be
+from optiland.optimization.variable.base import VariableBehavior
+
+
+class EdgeThicknessVariable(VariableBehavior):
+    """Represents a variable for the edge thickness between two surfaces."""
+
+    def __init__(self, optic, surface_number, edge_radius, apply_scaling=True, **kwargs):
+        super().__init__(optic, surface_number, apply_scaling, **kwargs)
+        self.edge_radius = edge_radius
+
+    def _get_sag(self):
+        surf_before = self._surfaces.surfaces[self.surface_number]
+        surf_after = self._surfaces.surfaces[self.surface_number + 1]
+        sag_before = surf_before.geometry.sag(0.0, self.edge_radius)
+        sag_after = surf_after.geometry.sag(0.0, self.edge_radius)
+        return sag_before, sag_after
+
+    def get_value(self):
+        """Return the current edge thickness value."""
+        center_t = self._surfaces.get_thickness(self.surface_number)[0]
+        sag_before, sag_after = self._get_sag()
+        value = center_t + sag_after - sag_before
+        if self.apply_scaling:
+            return self.scale(value)
+        return value
+
+    def update_value(self, new_value):
+        """Update the edge thickness to ``new_value``."""
+        if self.apply_scaling:
+            new_value = self.inverse_scale(new_value)
+        sag_before, sag_after = self._get_sag()
+        center_t = new_value - sag_after + sag_before
+        self.optic.set_thickness(center_t, self.surface_number)
+
+    def scale(self, value):
+        return value / 10.0 - 1.0
+
+    def inverse_scale(self, scaled_value):
+        return (scaled_value + 1.0) * 10.0
+
+    def __str__(self):
+        return f"Edge Thickness, Surface {self.surface_number}"

--- a/src/optiland/optiland/optimization/variable/variable.py
+++ b/src/optiland/optiland/optimization/variable/variable.py
@@ -23,6 +23,7 @@ from optiland.optimization.variable.reciprocal_radius import ReciprocalRadiusVar
 from optiland.optimization.variable.thickness import ThicknessVariable
 from optiland.optimization.variable.tilt import TiltVariable
 from optiland.optimization.variable.zernike_coeff import ZernikeCoeffVariable
+from optiland.optimization.variable.edge_thickness import EdgeThicknessVariable
 
 
 class Variable:
@@ -90,6 +91,7 @@ class Variable:
             "coeff_index",
             "axis",
             "glass_selection",
+            "edge_radius",
         }
 
     def _get_variable(self):
@@ -119,6 +121,7 @@ class Variable:
             "chebyshev_coeff": ChebyshevCoeffVariable,
             "zernike_coeff": ZernikeCoeffVariable,
             "reciprocal_radius": ReciprocalRadiusVariable,
+            "edge_thickness": EdgeThicknessVariable,
         }
 
         variable_class = variable_types.get(self.type)

--- a/src/optiland/tests/test_variable.py
+++ b/src/optiland/tests/test_variable.py
@@ -174,6 +174,34 @@ class TestThicknessVariable:
         assert_allclose(self.thickness_var.get_value(), 4.4)
 
 
+class TestEdgeThicknessVariable:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.optic = Objective60x()
+        self.edge_var = variable.EdgeThicknessVariable(
+            self.optic, 2, edge_radius=5.0
+        )
+
+    def test_get_value(self, set_test_backend):
+        expected = -0.5673074645035294
+        assert_allclose(self.edge_var.get_value(), expected)
+
+    def test_update_value(self, set_test_backend):
+        self.edge_var.update_value(-0.5)
+        assert_allclose(self.edge_var.get_value(), -0.5)
+
+    def test_get_value_no_scaling(self, set_test_backend):
+        self.optic = Objective60x()
+        self.edge_var = variable.EdgeThicknessVariable(
+            self.optic,
+            2,
+            edge_radius=5.0,
+            apply_scaling=False,
+        )
+        expected = 4.326925354964706
+        assert_allclose(self.edge_var.get_value(), expected)
+
+
 class TestIndexVariable:
     @pytest.fixture(autouse=True)
     def setup(self):


### PR DESCRIPTION
## Summary
- introduce `EdgeThicknessVariable` to handle lens edge thickness
- register new variable type and allow `edge_radius` attribute
- expose new variable in public API
- test the new variable behaviour

## Testing
- `pytest src/optiland/tests/test_variable.py::TestEdgeThicknessVariable::test_get_value -q` *(fails: ModuleNotFoundError: No module named 'vtk')*

------
https://chatgpt.com/codex/tasks/task_e_68802acaf5e0832d8cae06ba23927d53